### PR TITLE
Added the service_file_deps output field

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ A map of fully-qualified message names to a list of the messages and enumeration
 
 A map of fully-qualified service names to a list of the messages and enumerations they depend on.
 
+#### `service_file_deps`
+
+A map of fully-qualified service names to a list of the files containing messages and enumerations they depend on.
+
 ### Common Fields
 
 The descriptors describe below have some fields in common, so those are described here.

--- a/internal/docdata/docdata.go
+++ b/internal/docdata/docdata.go
@@ -287,6 +287,9 @@ type TemplateData struct {
 	// Map of fully-qualified service names to lists of dependent message and
 	// enumeration names.
 	ServiceDeps map[string][]string `json:"service_deps"`
+
+	// Map of fully-qualified service names to lists of dependent files.
+	ServiceFileDeps map[string][]string `json:"service_file_deps"`
 }
 
 func (ns Namespace) QualifyName(name string) string {

--- a/internal/util/fifo_set.go
+++ b/internal/util/fifo_set.go
@@ -1,0 +1,71 @@
+package util
+
+// BSD 2-Clause License
+//
+// Copyright (c) 2023 Don Owens <don@regexguy.com>.  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+type FifoSet[T comparable] struct {
+	Items   []T
+	ItemMap map[T]bool
+}
+
+func NewStringSet() *FifoSet[string] {
+	size := 2
+	return &FifoSet[string]{
+		Items:   make([]string, 0, size),
+		ItemMap: make(map[string]bool, size),
+	}
+}
+
+func NewIntSet() *FifoSet[int] {
+	size := 2
+	return &FifoSet[int]{
+		Items:   make([]int, 0, size),
+		ItemMap: make(map[int]bool, size),
+	}
+}
+
+func (s *FifoSet[T]) Add(item T) {
+	if _, ok := s.ItemMap[item]; ok {
+		return
+	}
+
+	s.Items = append(s.Items, item)
+	s.ItemMap[item] = true
+}
+
+func (s *FifoSet[T]) Update(items []T) {
+	for _, item := range items {
+		s.Add(item)
+	}
+}
+
+func (s *FifoSet[T]) GetItems() []T {
+	return s.Items
+}
+
+func (s *FifoSet[T]) Len() int {
+	return len(s.Items)
+}

--- a/tests/fifo_set_test.go
+++ b/tests/fifo_set_test.go
@@ -1,0 +1,46 @@
+package proto1_test
+
+import (
+	// Built-in/core modules.
+	"reflect"
+	"testing"
+
+	// First-party modules.
+	util "github.com/cuberat/protoc-gen-docjson/internal/util"
+)
+
+func TestStringSet(t *testing.T) {
+	expected := []string{"foo", "bar", "beefc0de"}
+	set := util.NewStringSet()
+	set.Add("foo")
+	set.Add("bar")
+	set.Add("foo")
+	set.Add("beefc0de")
+	set.Add("bar")
+	set.Add("beefc0de")
+
+	got := set.GetItems()
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("StringSet items incorrect: got %v, expected %v",
+			got, expected)
+		return
+	}
+}
+
+func TestIntSet(t *testing.T) {
+	expected := []int{2, 1, 3}
+	set := util.NewIntSet()
+	set.Add(2)
+	set.Add(1)
+	set.Add(3)
+	set.Add(2)
+	set.Add(3)
+	set.Add(1)
+
+	got := set.GetItems()
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("IntSet items incorrect: got %v, expected %v",
+			got, expected)
+		return
+	}
+}

--- a/tests/proto1_test.go
+++ b/tests/proto1_test.go
@@ -59,6 +59,83 @@ func TestComments(t *testing.T) {
 			do_check_enums(st, data)
 		},
 	)
+
+	t.Run("service_deps check",
+		func(st *testing.T) {
+			do_check_service_deps(st, data)
+		},
+	)
+
+	t.Run("service_file_dep check",
+		func(st *testing.T) {
+			do_check_service_file_deps(st, data)
+		},
+	)
+}
+
+func do_check_service_file_deps(t *testing.T, data map[string]any) {
+	svc_file_deps, ok := data["service_file_deps"].(map[string]any)
+	if !ok {
+		t.Errorf("wrong type for service_file_deps: got %T, "+
+			"expected map[string]any", data["service_file_deps"])
+		return
+	}
+
+	if len(svc_file_deps) != 1 {
+		t.Errorf("wrong number of items in service_file_deps: got %d, "+
+			"expected 1", len(svc_file_deps))
+		return
+	}
+
+	svc_name := "MyServices.Service.Tester"
+	expected_deps := []any{"tester.proto"}
+	deps, ok := svc_file_deps[svc_name].([]any)
+	if !ok {
+		t.Errorf("wrong type for svc dep list %q: got %T, expected []any",
+			svc_name, svc_file_deps[svc_name])
+		return
+	}
+	if !reflect.DeepEqual(deps, expected_deps) {
+		t.Errorf("wrong list of dependencies for svc %q: got %v, expected %v",
+			svc_name, deps, expected_deps)
+		return
+	}
+}
+
+func do_check_service_deps(t *testing.T, data map[string]any) {
+	svc_deps, ok := data["service_deps"].(map[string]any)
+	if !ok {
+		t.Errorf("wrong type for service_deps: got %T, "+
+			"expected map[string]any", data["service_deps"])
+		return
+	}
+
+	if len(svc_deps) != 1 {
+		t.Errorf("wrong number of items in service_deps: got %d, "+
+			"expected 1", len(svc_deps))
+		return
+	}
+
+	svc_name := "MyServices.Service.Tester"
+	this_svc_deps, ok := svc_deps[svc_name].([]any)
+	if !ok {
+		t.Errorf("wrong type for dep %q dep list: got %T, "+
+			"expected []any", svc_name, svc_deps[svc_name])
+		return
+	}
+
+	expected_deps := []any{
+		"MyServices.Tester.TesterRequest",
+		"MyServices.Tester.ClientInfo",
+		"MyServices.Tester.TesterResponse",
+		"MyServices.Tester.TesterResponse.ResponseThing",
+		"MyServices.Tester.TesterResponse.EmbeddedTester",
+	}
+	if !reflect.DeepEqual(this_svc_deps, expected_deps) {
+		t.Errorf("wrong service dep list for %q: got %v, expected %v",
+			svc_name, this_svc_deps, expected_deps)
+		return
+	}
 }
 
 func do_check_services(t *testing.T, data map[string]any) {


### PR DESCRIPTION
Added the `service_file_deps` output field, which is a map of fully-qualified service names to a list of the files containing messages and enumerations they depend on.